### PR TITLE
Support other shells than `bash`.

### DIFF
--- a/src/collective/recipe/sphinxbuilder/__init__.py
+++ b/src/collective/recipe/sphinxbuilder/__init__.py
@@ -92,7 +92,10 @@ class Recipe(object):
 
         # 4. CREATE CUSTOM "sphinx-build" SCRIPT
         log.info('writing custom sphinx-builder script..')
-        script = ['cd %s' % self.build_dir]
+        script = [
+            '#!/bin/bash',
+            'cd %s' % self.build_dir
+        ]
         if 'doctest' in self.outputs:
             script.append('make doctest')
         if 'html' in self.outputs:

--- a/src/collective/recipe/sphinxbuilder/docs/history.rst
+++ b/src/collective/recipe/sphinxbuilder/docs/history.rst
@@ -5,7 +5,7 @@ Changes
 1.1 (unreleased)
 ================
 
-- Nothing changed yet.
+- Support other shells than `bash`. [icemac]
 
 
 1.0 (2016-07-11)

--- a/src/collective/recipe/sphinxbuilder/docs/usage.rst
+++ b/src/collective/recipe/sphinxbuilder/docs/usage.rst
@@ -52,6 +52,7 @@ The content of the script is a simple shell script::
 
     >>> script = join(sample_buildout, 'bin', 'sphinxbuilder')
     >>> print(open(script).read())
+    #!/bin/bash
     cd ...docs
     make html
 
@@ -84,6 +85,7 @@ If we want `latex`, we need to explicitly define it::
 Let's see our script now::
 
     >>> cat(script)
+    #!/bin/bash
     cd ...docs
     make html
     make latex
@@ -126,6 +128,7 @@ If we want `pdf`, we need to explicitly define it::
 Let's see our script now::
 
     >>> cat(script)
+    #!/bin/bash
     cd ...docs
     make html
     make latex
@@ -159,6 +162,7 @@ If we want `epub`, like pdf we need to explicitly define it::
 Let's see our script now::
 
     >>> cat(script)
+    #!/bin/bash
     cd ...docs
     make html
     make epub
@@ -188,6 +192,7 @@ We can also have the script run any doctests in the docs while building::
 Let's see our script now::
 
     >>> cat(script)
+    #!/bin/bash
     cd ...docs
     make doctest
     make html


### PR DESCRIPTION
Without this change `fish` fails with the error:

Failed to execute process 'bin/make-docs'. Reason:
exec: Exec format error
The file 'bin/make-docs' is marked as an executable but could not be run by the operating system.

**Caution:** This change might break windows compatibility but I cannot check this.